### PR TITLE
Fix Wallpaper image size

### DIFF
--- a/config/awesome/floppy/module/dynamic-wallpaper.lua
+++ b/config/awesome/floppy/module/dynamic-wallpaper.lua
@@ -251,11 +251,11 @@ local set_wallpaper = function(path)
 	if wall_config.stretch then
 		for s in screen do
 			-- Update wallpaper based on the data in the array
-			gears.wallpaper.maximized (path, s)
+			gears.wallpaper.maximized (path, s,true)
 		end
 	else
 		-- Update wallpaper based on the data in the array
-		gears.wallpaper.maximized (path)
+		gears.wallpaper.maximized (path,nil,true)
 	end
 end
 

--- a/config/awesome/gnawesome/module/dynamic-wallpaper.lua
+++ b/config/awesome/gnawesome/module/dynamic-wallpaper.lua
@@ -251,11 +251,11 @@ local set_wallpaper = function(path)
 	if wall_config.stretch then
 		for s in screen do
 			-- Update wallpaper based on the data in the array
-			gears.wallpaper.maximized (path, s)
+			gears.wallpaper.maximized (path, s,true)
 		end
 	else
 		-- Update wallpaper based on the data in the array
-		gears.wallpaper.maximized (path)
+		gears.wallpaper.maximized (path,nil,true)
 	end
 end
 

--- a/config/awesome/linear/module/dynamic-wallpaper.lua
+++ b/config/awesome/linear/module/dynamic-wallpaper.lua
@@ -251,11 +251,11 @@ local set_wallpaper = function(path)
 	if wall_config.stretch then
 		for s in screen do
 			-- Update wallpaper based on the data in the array
-			gears.wallpaper.maximized (path, s)
+			gears.wallpaper.maximized (path, s,true)
 		end
 	else
 		-- Update wallpaper based on the data in the array
-		gears.wallpaper.maximized (path)
+		gears.wallpaper.maximized (path,nil,true)
 	end
 end
 

--- a/config/awesome/surreal/module/dynamic-wallpaper.lua
+++ b/config/awesome/surreal/module/dynamic-wallpaper.lua
@@ -251,11 +251,11 @@ local set_wallpaper = function(path)
 	if wall_config.stretch then
 		for s in screen do
 			-- Update wallpaper based on the data in the array
-			gears.wallpaper.maximized (path, s)
+			gears.wallpaper.maximized (path, s,true)
 		end
 	else
 		-- Update wallpaper based on the data in the array
-		gears.wallpaper.maximized (path)
+		gears.wallpaper.maximized (path,nil,true)
 	end
 end
 


### PR DESCRIPTION
If the image res was higher than the desktop res, only part of the image would be displayed.