### PR TITLE
Fix Wallpaper image size again

### DIFF
--- a/config/awesome/floppy/rc.lua
+++ b/config/awesome/floppy/rc.lua
@@ -68,7 +68,7 @@ screen.connect_signal(
 
 				elseif beautiful.wallpaper:sub(1, #'/') == '/' then
 					-- If beautiful.wallpaper is path/image
-					gears.wallpaper.maximized(beautiful.wallpaper, s)
+					gears.wallpaper.maximized(beautiful.wallpaper, s,true)
 				end
 			else
 				beautiful.wallpaper(s)

--- a/config/awesome/gnawesome/rc.lua
+++ b/config/awesome/gnawesome/rc.lua
@@ -68,7 +68,7 @@ screen.connect_signal(
 
 				elseif beautiful.wallpaper:sub(1, #'/') == '/' then
 					-- If beautiful.wallpaper is path/image
-					gears.wallpaper.maximized(beautiful.wallpaper, s)
+					gears.wallpaper.maximized(beautiful.wallpaper, s,true)
 				end
 			else
 				beautiful.wallpaper(s)

--- a/config/awesome/linear/rc.lua
+++ b/config/awesome/linear/rc.lua
@@ -68,7 +68,7 @@ screen.connect_signal(
 
 				elseif beautiful.wallpaper:sub(1, #'/') == '/' then
 					-- If beautiful.wallpaper is path/image
-					gears.wallpaper.maximized(beautiful.wallpaper, s)
+					gears.wallpaper.maximized(beautiful.wallpaper, s,true)
 				end
 			else
 				beautiful.wallpaper(s)

--- a/config/awesome/surreal/rc.lua
+++ b/config/awesome/surreal/rc.lua
@@ -68,7 +68,7 @@ screen.connect_signal(
 
 				elseif beautiful.wallpaper:sub(1, #'/') == '/' then
 					-- If beautiful.wallpaper is path/image
-					gears.wallpaper.maximized(beautiful.wallpaper, s)
+					gears.wallpaper.maximized(beautiful.wallpaper, s,true)
 				end
 			else
 				beautiful.wallpaper(s)


### PR DESCRIPTION
If the image res was higher than the desktop res, only part of the image would be displayed.
This would only occur on restart, but this fixes this little loophole.